### PR TITLE
Add support for AMD

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,7 @@
 {
   "globals": {
-    "QUnit": false
+    "QUnit": false,
+    "define": false
   },
 
   "bitwise": true,

--- a/qunit-assert-close.js
+++ b/qunit-assert-close.js
@@ -1,106 +1,120 @@
-/**
- * Checks that the first two arguments are equal, or are numbers close enough to be considered equal
- * based on a specified maximum allowable difference.
- *
- * @example assert.close(3.141, Math.PI, 0.001);
- *
- * @param Number actual
- * @param Number expected
- * @param Number maxDifference (the maximum inclusive difference allowed between the actual and expected numbers)
- * @param String message (optional)
- */
-function close(actual, expected, maxDifference, message) {
-  var actualDiff = (actual === expected) ? 0 : Math.abs(actual - expected),
-      result = actualDiff <= maxDifference;
-  message = message || (actual + " should be within " + maxDifference + " (inclusive) of " + expected + (result ? "" : ". Actual: " + actualDiff));
-  QUnit.push(result, actual, expected, message);
-}
+(function (factory) {
+  if (typeof define === "function" && define.amd) {
 
+    // AMD. Register as an anonymous module.
+    define([
+      "qunit"
+    ], factory);
+  } else {
 
-/**
- * Checks that the first two arguments are equal, or are numbers close enough to be considered equal
- * based on a specified maximum allowable difference percentage.
- *
- * @example assert.close.percent(155, 150, 3.4);  // Difference is ~3.33%
- *
- * @param Number actual
- * @param Number expected
- * @param Number maxPercentDifference (the maximum inclusive difference percentage allowed between the actual and expected numbers)
- * @param String message (optional)
- */
-close.percent = function closePercent(actual, expected, maxPercentDifference, message) {
-  var actualDiff, result;
-  if (actual === expected) {
-    actualDiff = 0;
-    result = actualDiff <= maxPercentDifference;
+    // Browser globals
+    factory(QUnit);
   }
-  else if (actual !== 0 && expected !== 0 && expected !== Infinity && expected !== -Infinity) {
-    actualDiff = Math.abs(100 * (actual - expected) / expected);
-    result = actualDiff <= maxPercentDifference;
+}(function (QUnit) {
+  /**
+   * Checks that the first two arguments are equal, or are numbers close enough to be considered equal
+   * based on a specified maximum allowable difference.
+   *
+   * @example assert.close(3.141, Math.PI, 0.001);
+   *
+   * @param Number actual
+   * @param Number expected
+   * @param Number maxDifference (the maximum inclusive difference allowed between the actual and expected numbers)
+   * @param String message (optional)
+   */
+  function close(actual, expected, maxDifference, message) {
+    var actualDiff = (actual === expected) ? 0 : Math.abs(actual - expected),
+        result = actualDiff <= maxDifference;
+    message = message || (actual + " should be within " + maxDifference + " (inclusive) of " + expected + (result ? "" : ". Actual: " + actualDiff));
+    QUnit.push(result, actual, expected, message);
   }
-  else {
-    // Dividing by zero (0)!  Should return `false` unless the max percentage was `Infinity`
-    actualDiff = Infinity;
-    result = maxPercentDifference === Infinity;
+
+
+  /**
+   * Checks that the first two arguments are equal, or are numbers close enough to be considered equal
+   * based on a specified maximum allowable difference percentage.
+   *
+   * @example assert.close.percent(155, 150, 3.4);  // Difference is ~3.33%
+   *
+   * @param Number actual
+   * @param Number expected
+   * @param Number maxPercentDifference (the maximum inclusive difference percentage allowed between the actual and expected numbers)
+   * @param String message (optional)
+   */
+  close.percent = function closePercent(actual, expected, maxPercentDifference, message) {
+    var actualDiff, result;
+    if (actual === expected) {
+      actualDiff = 0;
+      result = actualDiff <= maxPercentDifference;
+    }
+    else if (actual !== 0 && expected !== 0 && expected !== Infinity && expected !== -Infinity) {
+      actualDiff = Math.abs(100 * (actual - expected) / expected);
+      result = actualDiff <= maxPercentDifference;
+    }
+    else {
+      // Dividing by zero (0)!  Should return `false` unless the max percentage was `Infinity`
+      actualDiff = Infinity;
+      result = maxPercentDifference === Infinity;
+    }
+    message = message || (actual + " should be within " + maxPercentDifference + "% (inclusive) of " + expected + (result ? "" : ". Actual: " + actualDiff + "%"));
+
+    QUnit.push(result, actual, expected, message);
+  };
+
+
+  /**
+   * Checks that the first two arguments are numbers with differences greater than the specified
+   * minimum difference.
+   *
+   * @example assert.notClose(3.1, Math.PI, 0.001);
+   *
+   * @param Number actual
+   * @param Number expected
+   * @param Number minDifference (the minimum exclusive difference allowed between the actual and expected numbers)
+   * @param String message (optional)
+   */
+  function notClose(actual, expected, minDifference, message) {
+    var actualDiff = Math.abs(actual - expected),
+        result = actualDiff > minDifference;
+    message = message || (actual + " should not be within " + minDifference + " (exclusive) of " + expected + (result ? "" : ". Actual: " + actualDiff));
+    QUnit.push(result, actual, expected, message);
   }
-  message = message || (actual + " should be within " + maxPercentDifference + "% (inclusive) of " + expected + (result ? "" : ". Actual: " + actualDiff + "%"));
-
-  QUnit.push(result, actual, expected, message);
-};
 
 
-/**
- * Checks that the first two arguments are numbers with differences greater than the specified
- * minimum difference.
- *
- * @example assert.notClose(3.1, Math.PI, 0.001);
- *
- * @param Number actual
- * @param Number expected
- * @param Number minDifference (the minimum exclusive difference allowed between the actual and expected numbers)
- * @param String message (optional)
- */
-function notClose(actual, expected, minDifference, message) {
-  var actualDiff = Math.abs(actual - expected),
-      result = actualDiff > minDifference;
-  message = message || (actual + " should not be within " + minDifference + " (exclusive) of " + expected + (result ? "" : ". Actual: " + actualDiff));
-  QUnit.push(result, actual, expected, message);
-}
+  /**
+   * Checks that the first two arguments are numbers with differences greater than the specified
+   * minimum difference percentage.
+   *
+   * @example assert.notClose.percent(156, 150, 3.5);  // Difference is 4.0%
+   *
+   * @param Number actual
+   * @param Number expected
+   * @param Number minPercentDifference (the minimum exclusive difference percentage allowed between the actual and expected numbers)
+   * @param String message (optional)
+   */
+  notClose.percent = function notClosePercent(actual, expected, minPercentDifference, message) {
+    var actualDiff, result;
+    if (actual === expected) {
+      actualDiff = 0;
+      result = actualDiff > minPercentDifference;
+    }
+    else if (actual !== 0 && expected !== 0 && expected !== Infinity && expected !== -Infinity) {
+      actualDiff = Math.abs(100 * (actual - expected) / expected);
+      result = actualDiff > minPercentDifference;
+    }
+    else {
+      // Dividing by zero (0)!  Should only return `true` if the min percentage was `Infinity`
+      actualDiff = Infinity;
+      result = minPercentDifference !== Infinity;
+    }
+    message = message || (actual + " should not be within " + minPercentDifference + "% (exclusive) of " + expected + (result ? "" : ". Actual: " + actualDiff + "%"));
+
+    QUnit.push(result, actual, expected, message);
+  };
 
 
-/**
- * Checks that the first two arguments are numbers with differences greater than the specified
- * minimum difference percentage.
- *
- * @example assert.notClose.percent(156, 150, 3.5);  // Difference is 4.0%
- *
- * @param Number actual
- * @param Number expected
- * @param Number minPercentDifference (the minimum exclusive difference percentage allowed between the actual and expected numbers)
- * @param String message (optional)
- */
-notClose.percent = function notClosePercent(actual, expected, minPercentDifference, message) {
-  var actualDiff, result;
-  if (actual === expected) {
-    actualDiff = 0;
-    result = actualDiff > minPercentDifference;
-  }
-  else if (actual !== 0 && expected !== 0 && expected !== Infinity && expected !== -Infinity) {
-    actualDiff = Math.abs(100 * (actual - expected) / expected);
-    result = actualDiff > minPercentDifference;
-  }
-  else {
-    // Dividing by zero (0)!  Should only return `true` if the min percentage was `Infinity`
-    actualDiff = Infinity;
-    result = minPercentDifference !== Infinity;
-  }
-  message = message || (actual + " should not be within " + minPercentDifference + "% (exclusive) of " + expected + (result ? "" : ". Actual: " + actualDiff + "%"));
-
-  QUnit.push(result, actual, expected, message);
-};
-
-
-QUnit.extend(QUnit.assert, {
-  close: close,
-  notClose: notClose
-});
+  QUnit.extend(QUnit.assert, {
+    close: close,
+    notClose: notClose
+  });
+}));


### PR DESCRIPTION
As for our transition of jQuery UI to intern testing framework, we need to alias QUnit as intern!qunit and require it through amd. It would be better to have support for both global and amd modules.